### PR TITLE
No End Date (Optional UNTIL/COUNT)

### DIFF
--- a/fields/class-acf-field-rrule.php
+++ b/fields/class-acf-field-rrule.php
@@ -470,9 +470,9 @@ if (! class_exists('acf_field_rrule')) :
 							'value' => $field['value'] ? $field['value']['end_type'] : null,
 	                        'class' => 'end-type-select',
 							'choices' => array(
-								'none'	=> __('No end date', 'acf-rrule'),
 								'date' => __('At a specific date', 'acf-rrule'),
 								'count' =>  __('After a number of occurences', 'acf-rrule'),
+								'none'	=> __('No end date', 'acf-rrule'),
 							),
 						) ); ?>
 					</div>

--- a/fields/class-acf-field-rrule.php
+++ b/fields/class-acf-field-rrule.php
@@ -470,6 +470,7 @@ if (! class_exists('acf_field_rrule')) :
 							'value' => $field['value'] ? $field['value']['end_type'] : null,
 	                        'class' => 'end-type-select',
 							'choices' => array(
+								'none'	=> __('No end date', 'acf-rrule'),
 								'date' => __('At a specific date', 'acf-rrule'),
 								'count' =>  __('After a number of occurences', 'acf-rrule'),
 							),
@@ -655,9 +656,11 @@ if (! class_exists('acf_field_rrule')) :
 					if ($rule->getUntil()) {
 						$new_value['end_type'] = 'date';
 						$new_value['end_date'] =  $rule->getUntil()->format('Ymd');
-					} else {
+					} else if ($rule->getCount()) {
 						$new_value['end_type'] = 'count';
 						$new_value['occurence_count'] =  $rule->getCount();
+					} else {
+						$new_value['end_type'] = 'none';
 					}
 
 	                $locale = explode('_', get_locale());
@@ -718,6 +721,7 @@ if (! class_exists('acf_field_rrule')) :
 				}
 
 				$rule = new Rule;
+
 
 				$rule->setTimezone($field['timezone'])
 					 ->setStartDate($start_date, true)

--- a/fields/class-acf-field-rrule.php
+++ b/fields/class-acf-field-rrule.php
@@ -722,8 +722,16 @@ if (! class_exists('acf_field_rrule')) :
 
 				$rule = new Rule;
 
+				// Ensure timezone arg is never blank
+				$timezone = $field['timezone'];
+				if( empty( $timezone ) ) {
+					$timezone = get_option( 'timezone_string' );
+				}
+				if( empty( $timezone ) ) {
+					$timezone = get_option( 'gmt_offset' );
+				}
 
-				$rule->setTimezone($field['timezone'])
+				$rule->setTimezone( $timezone )
 					 ->setStartDate($start_date, true)
 					 ->setFreq($value['frequency'])
 					 ->setInterval($value['interval']);

--- a/fields/class-acf-field-rrule.php
+++ b/fields/class-acf-field-rrule.php
@@ -472,7 +472,7 @@ if (! class_exists('acf_field_rrule')) :
 							'choices' => array(
 								'date' => __('At a specific date', 'acf-rrule'),
 								'count' =>  __('After a number of occurences', 'acf-rrule'),
-								'none'	=> __('No end date', 'acf-rrule'),
+								'none'	=> __('Never', 'acf-rrule'),
 							),
 						) ); ?>
 					</div>


### PR DESCRIPTION
Great plugin! I'm using it in one of my current projects. We have a use case that doesn't require an end date/time, and wanted to make this field a little more friendly for users when until date or count is not required.

### No End Date (Optional UNTIL/COUNT)
[RFC 5545 3.3.10](https://tools.ietf.org/html/rfc5545#section-3.3.10) specifies that `UNTIL` and `COUNT` are optional. This adds a third option ("No end date") to the `End Date` dropdown. I recognize that leaving these fields blank does not include them in the resulting `rrule` string, however I feel this approach is much more explicit for the user to understand.

---

### Bug fix: Timezone Fallback
In WordPress, the `timezone_string` option has a default value of `NULL` ([Options Reference](https://codex.wordpress.org/Option_Reference)). I ran into an error where `$field['timezone']` was returning a blank string because it relies on `timezone_string` to have a value. I added sensible fallbacks for timezone retrieval (in order: `$field['timezone']`, `get_options('timezone_string')`, `get_options('gmt_offset')`). This will ensure `$rule->setTimezone` will always receive a valid timezone to prevent this error.

--

TODO:

- [x] Change language to 'Never` in drop down.