### PR TITLE
[WIP] Switch rrule library to rlanvin/php-rrule (fixes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ACF RRule Field
 
-Create recurring rules within a single ACF field and retrieve all the dates using the [simshaun/recurr](https://github.com/simshaun/recurr) package.
+Create recurring rules within a single ACF field and retrieve all the dates using the [rlanvin/php-rrule](https://github.com/rlanvin/php-rrule) package.
 
 ![ACF RRule Screenshot](https://pixelparfait.fr/_github/acf-rrule.png)
 

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,13 @@
     "support": {
         "issues": "https://github.com/marcbelletre/acf-rrule/issues"
     },
+    "autoload": {
+        "psr-4": {
+            "AcfRRule\\": "src/"
+        }
+    },
     "require": {
-        "simshaun/recurr": "^4.0",
+        "rlanvin/php-rrule": "^v1.6.3",
         "composer/installers": "~1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c30f9a9a5de399f90436768128439030",
+    "content-hash": "f47c2b21b41216444ba92096cd5299a5",
     "packages": [
         {
             "name": "composer/installers",
@@ -157,131 +157,52 @@
             "time": "2021-04-28T06:42:17+00:00"
         },
         {
-            "name": "doctrine/collections",
-            "version": "1.6.7",
+            "name": "rlanvin/php-rrule",
+            "version": "v1.6.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/collections.git",
-                "reference": "55f8b799269a1a472457bd1a41b4f379d4cfba4a"
+                "url": "https://github.com/rlanvin/php-rrule.git",
+                "reference": "1373df401e0926cf7548716dabbc0d19603a144d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/55f8b799269a1a472457bd1a41b4f379d4cfba4a",
-                "reference": "55f8b799269a1a472457bd1a41b4f379d4cfba4a",
+                "url": "https://api.github.com/repos/rlanvin/php-rrule/zipball/1373df401e0926cf7548716dabbc0d19603a144d",
+                "reference": "1373df401e0926cf7548716dabbc0d19603a144d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3 || ^8.0"
+                "php": ">=5.3.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
-                "phpstan/phpstan-shim": "^0.9.2",
-                "phpunit/phpunit": "^7.0",
-                "vimeo/psalm": "^3.8.1"
+                "phpunit/phpunit": "^4.8|^5.5|^6.5"
+            },
+            "suggest": {
+                "ext-intl": "Intl extension is needed for humanReadable()"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections"
+                    "RRule\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.",
-            "homepage": "https://www.doctrine-project.org/projects/collections.html",
+            "description": "Lightweight and fast recurrence rules for PHP (RFC 5545)",
+            "homepage": "https://github.com/rlanvin/php-rrule",
             "keywords": [
-                "array",
-                "collections",
-                "iterators",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/1.6.7"
-            },
-            "time": "2020-07-27T17:53:49+00:00"
-        },
-        {
-            "name": "simshaun/recurr",
-            "version": "v4.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/simshaun/recurr.git",
-                "reference": "08b0b46879f598cd11dd42b4c1a9c221a0562749"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/simshaun/recurr/zipball/08b0b46879f598cd11dd42b4c1a9c221a0562749",
-                "reference": "08b0b46879f598cd11dd42b4c1a9c221a0562749",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/collections": "~1.3",
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Recurr\\": "src/Recurr/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Shaun Simmons",
-                    "email": "shaun@shaun.pub",
-                    "homepage": "https://shaun.pub"
-                }
-            ],
-            "description": "PHP library for working with recurrence rules",
-            "homepage": "https://github.com/simshaun/recurr",
-            "keywords": [
-                "dates",
-                "events",
+                "date",
+                "ical",
                 "recurrence",
                 "recurring",
                 "rrule"
             ],
             "support": {
-                "issues": "https://github.com/simshaun/recurr/issues",
-                "source": "https://github.com/simshaun/recurr/tree/v4.0.5"
+                "issues": "https://github.com/rlanvin/php-rrule/issues",
+                "source": "https://github.com/rlanvin/php-rrule/tree/v1.6.3"
             },
-            "time": "2021-03-25T23:00:49+00:00"
+            "time": "2019-01-13T09:49:03+00:00"
         }
     ],
     "packages-dev": [],

--- a/fields/class-acf-field-rrule.php
+++ b/fields/class-acf-field-rrule.php
@@ -339,7 +339,7 @@ if (! class_exists('acf_field_rrule')) :
 						<div class="acf-input">
 							<div class="acf-button-group">
 								<?php foreach ($weekdays as $key => $value) : ?>
-		                            <?php $selected = is_array($field['value']) && in_array($key, $field['value']['weekdays']); ?>
+		                            <?php $selected = is_array($field['value']) && in_array($key, $field['value']['weekdays'], true); ?>
 
 									<label<?=($selected ? ' class="selected"' : '')?>>
 										<input type="checkbox" name="<?=$field['name']?>[weekdays][]" value="<?=$key?>"<?=($selected ? ' checked' : '')?>> <?=$value?>
@@ -353,7 +353,7 @@ if (! class_exists('acf_field_rrule')) :
 						<div class="acf-columns">
 							<div class="acf-column">
 								<div class="acf-label is-inline">
-									<input id="acf-<?=$field['name']?>-bymonthdays" type="radio" name="<?=$field['name']?>[monthly_by]" value="monthdays"<?=(is_array($field['value']) && $field['value']['monthly_by'] == 'monthdays' ? ' checked' : '')?>>
+									<input id="acf-<?=$field['name']?>-bymonthdays" type="radio" name="<?=$field['name']?>[monthly_by]" value="monthdays"<?=(is_array($field['value']) && $field['value']['monthly_by'] === 'monthdays' ? ' checked' : '')?>>
 									<label for="acf-<?=$field['name']?>-bymonthdays">
 										<?php _e('Month days', 'acf-rrule-field'); ?>
 									</label>
@@ -361,12 +361,12 @@ if (! class_exists('acf_field_rrule')) :
 
 								<?php $days = range(1, 31); ?>
 
-								<div class="acf-input<?=$field['value']['monthly_by'] != 'monthdays' ? ' is-disabled' : ''?>" data-monthly-by="monthdays">
+								<div class="acf-input<?=$field['value']['monthly_by'] !== 'monthdays' ? ' is-disabled' : ''?>" data-monthly-by="monthdays">
 									<table class="acf-rrule-monthdays">
 										<?php foreach (array_chunk($days, 7) as $week) : ?>
 											<tr>
 												<?php foreach ($week as $day) : ?>
-		                                            <?php $selected = is_array($field['value']) && in_array($day, $field['value']['monthdays']); ?>
+		                                            <?php $selected = is_array($field['value']) && in_array($day, $field['value']['monthdays'], true); ?>
 
 													<td>
 														<input id="acf-<?=$field['name']?>-monthdays-<?=$day?>" type="checkbox" name="<?=$field['name']?>[monthdays][]" value="<?=$day?>"<?=($selected ? ' checked' : '')?>>
@@ -381,13 +381,13 @@ if (! class_exists('acf_field_rrule')) :
 
 							<div class="acf-column">
 								<div class="acf-label is-inline">
-									<input id="acf-<?=$field['name']?>-setpos" type="radio" name="<?=$field['name']?>[monthly_by]" value="setpos"<?=(is_array($field['value']) && $field['value']['monthly_by'] == 'setpos' ? ' checked' : '')?>>
+									<input id="acf-<?=$field['name']?>-setpos" type="radio" name="<?=$field['name']?>[monthly_by]" value="setpos"<?=(is_array($field['value']) && $field['value']['monthly_by'] === 'setpos' ? ' checked' : '')?>>
 									<label for="acf-<?=$field['name']?>-setpos">
 										<?php _e('Weekdays', 'acf-rrule-field'); ?>
 									</label>
 								</div>
 
-								<div class="acf-input<?=(is_array($field['value']) && $field['value']['monthly_by'] != 'setpos' ? ' is-disabled' : '')?>" data-monthly-by="setpos">
+								<div class="acf-input<?=(is_array($field['value']) && $field['value']['monthly_by'] !== 'setpos' ? ' is-disabled' : '')?>" data-monthly-by="setpos">
                                     <div class="acf-columns">
                                         <div class="acf-column">
                                             <ul class="acf-checkbox-list">
@@ -406,7 +406,7 @@ if (! class_exists('acf_field_rrule')) :
                                                     $selected = false;
 
                                                     if (is_array($field['value']) && is_array($field['value']['bysetpos'])) {
-                                                        $selected = in_array($key, $field['value']['bysetpos']);
+                                                        $selected = in_array($key, $field['value']['bysetpos'], true);
                                                     }
                                                     ?>
 
@@ -423,7 +423,7 @@ if (! class_exists('acf_field_rrule')) :
                                         <div class="acf-column">
                                             <ul class="acf-checkbox-list">
                                                 <?php foreach ($weekdays as $key => $value) : ?>
-                                                    <?php $selected = is_array($field['value']) && in_array($key, $field['value']['weekdays']); ?>
+                                                    <?php $selected = is_array($field['value']) && in_array($key, $field['value']['weekdays'], true); ?>
 
                                                     <li>
                                                         <label<?=($selected ? ' class="selected"' : '')?>>
@@ -464,7 +464,7 @@ if (! class_exists('acf_field_rrule')) :
 
 							<ul class="acf-checkbox-list acf-hl">
 								<?php foreach ($months as $key => $month) : ?>
-		                            <?php $selected = is_array($field['value']) && in_array($key, $field['value']['months']); ?>
+		                            <?php $selected = is_array($field['value']) && in_array($key, $field['value']['months'], true); ?>
 
 									<li>
 										<label<?=($selected ? ' class="selected"' : '')?>>
@@ -663,7 +663,7 @@ if (! class_exists('acf_field_rrule')) :
 					$new_value['monthdays'] = $rule->getByMonthDay() ?: array();
 					$new_value['months'] = $rule->getByMonth() ?: array();
 
-					if ($new_value['frequency'] == 'MONTHLY') {
+					if ($new_value['frequency'] === 'MONTHLY') {
 						if (sizeof($new_value['weekdays']) > 0) {
 							$new_value['monthly_by'] = 'setpos';
 							$set_position = $rule->getBySetPosition();

--- a/fields/class-acf-field-rrule.php
+++ b/fields/class-acf-field-rrule.php
@@ -491,7 +491,7 @@ if (! class_exists('acf_field_rrule')) :
 		                        'class' => 'end-type-select',
 								'choices' => array(
 									'date' => __('At a specific date', 'acf-rrule-field'),
-									'count' =>  __('After a number of occurences', 'acf-rrule-field'),
+									'count' =>  __('After a number of occurrences', 'acf-rrule-field'),
 									'none'	=> __('Never', 'acf-rrule-field'),
 								),
 							) ); ?>
@@ -500,12 +500,12 @@ if (! class_exists('acf_field_rrule')) :
 
 					<div class="acf-field" data-end-type="count">
 						<?php
-						$occurence_count = array(
-							'id' => $field['id'] . '-occurence-count',
-							'name' => $field['name'] . '[occurence_count]',
+						$occurrence_count = array(
+							'id' => $field['id'] . '-occurrence-count',
+							'name' => $field['name'] . '[occurrence_count]',
 							'type' => 'number',
 							'class' => 'acf-is-prepended acf-is-appended',
-							'value'	=> is_array($field['value']) ? $field['value']['occurence_count'] : null,
+							'value'	=> is_array($field['value']) ? $field['value']['occurrence_count'] : null,
 							'min' => 1,
 							'step' => 1,
 						);
@@ -513,7 +513,7 @@ if (! class_exists('acf_field_rrule')) :
 
 						<div class="acf-input">
 							<div class="acf-input-prepend"><?php _e('After', 'acf-rrule-field'); ?></div>
-							<div class="acf-input-append"><?php _e('occurence(s)', 'acf-rrule-field'); ?></div>
+							<div class="acf-input-append"><?php _e('occurrence(s)', 'acf-rrule-field'); ?></div>
 							<div class="acf-input-wrap">
 								<?php acf_text_input( $occurrence_count ); ?>
 							</div>
@@ -643,7 +643,7 @@ if (! class_exists('acf_field_rrule')) :
 				'byweekday' => [],
 				'end_type' => null,
 				'end_date' => null,
-				'occurence_count' => null,
+				'occurrence_count' => null,
 	            'dates_collection' => null,
 	            'text' => null,
 			);
@@ -679,7 +679,7 @@ if (! class_exists('acf_field_rrule')) :
 						$new_value['end_date'] =  $rule->getUntil()->format('Ymd');
 					} else if ($rule->getCount()) {
 						$new_value['end_type'] = 'count';
-						$new_value['occurence_count'] =  $rule->getCount();
+						$new_value['occurrence_count'] =  $rule->getCount();
 					} else {
 						$new_value['end_type'] = 'none';
 					}
@@ -786,7 +786,7 @@ if (! class_exists('acf_field_rrule')) :
 
 						break;
 					case 'count':
-						$rule->setCount($value['occurence_count']);
+						$rule->setCount($value['occurrence_count']);
 						break;
 					default: break;
 				}

--- a/fields/class-acf-field-rrule.php
+++ b/fields/class-acf-field-rrule.php
@@ -196,7 +196,7 @@ if (! class_exists('acf_field_rrule')) :
 						<div class="acf-columns">
 							<div class="acf-column">
 								<div class="acf-field acf-field-date-picker is-required" data-type="date_picker">
-									<div <?php acf_esc_attr_e( $datepicker_options ); ?>>
+									<div <?php echo acf_esc_attrs( $datepicker_options ); ?>>
 										<?php
 										$start_date_hidden = '';
 										$start_date_display = '';
@@ -231,7 +231,7 @@ if (! class_exists('acf_field_rrule')) :
 							<?php if ($field['allow_time']) : ?>
 								<div class="acf-column">
 									<div class="acf-field acf-field-time-picker is-required" data-type="time_picker">
-										<div <?php acf_esc_attr_e( $timepicker_options ); ?>>
+										<div <?php echo acf_esc_attrs( $timepicker_options ); ?>>
 											<?php
 											$start_time = '';
 
@@ -515,13 +515,13 @@ if (! class_exists('acf_field_rrule')) :
 							<div class="acf-input-prepend"><?php _e('After', 'acf-rrule-field'); ?></div>
 							<div class="acf-input-append"><?php _e('occurence(s)', 'acf-rrule-field'); ?></div>
 							<div class="acf-input-wrap">
-								<?php acf_text_input( $occurence_count ); ?>
+								<?php acf_text_input( $occurrence_count ); ?>
 							</div>
 						</div>
 					</div>
 
 					<div class="acf-field acf-field-date-picker" data-type="date_picker" data-end-type="date">
-						<div <?php acf_esc_attr_e( $datepicker_options ); ?>>
+						<div <?php echo acf_esc_attrs( $datepicker_options ); ?>>
 							<?php
 							$end_date_hidden = '';
 							$end_date_display = '';

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -1,0 +1,803 @@
+<?php
+
+namespace AcfRRule;
+
+use DateTime;
+use Exception;
+use InvalidArgumentException;
+use function RRule\not_empty;
+
+class RRule
+    extends
+    \RRule\RRule
+{
+
+    public function getByDay()
+    {
+
+        return $this->byweekday;
+    }
+
+
+    public function getByDayAsText()
+    {
+
+        return array_intersect_key( array_flip( self::$week_days ), array_flip( $this->byweekday ) );
+    }
+
+
+    /**
+     * @return int[]|null
+     */
+    public function getByHour()
+    {
+
+        if ( ! empty( $this->byhour ) )
+        {
+            return $this->byhour;
+        }
+
+        if ( $this->freq < self::HOURLY )
+        {
+            return [
+                $this->dtstart
+                    ? (int) $this->dtstart->format( 'G' )
+                    : 0,
+            ];
+        }
+
+        return null;
+    }
+
+
+    /**
+     * @return int[]|null
+     */
+    public function getByMinute()
+    {
+
+        if ( ! empty( $this->byminute ) )
+        {
+            return $this->byminute;
+        }
+
+        if ( $this->freq < self::MINUTELY )
+        {
+            return [
+                $this->dtstart
+                    ? (int) $this->dtstart->format( 'i' )
+                    : 0,
+            ];
+        }
+
+        return null;
+    }
+
+
+    public function getByMonth()
+    {
+
+        return $this->bymonth;
+    }
+
+
+    public function getByMonthDay()
+    {
+
+        return $this->bymonthday;
+    }
+
+
+    public function getBySecond()
+    {
+
+        return $this->bysecond
+            ?: [
+                $this->dtstart
+                    ? (int) $this->dtstart->format( 's' )
+                    : 0,
+            ];
+    }
+
+
+    public function getBySetPosition()
+    {
+
+        return $this->bysetpos;
+    }
+
+
+    public function getCount()
+    {
+
+        return $this->count;
+    }
+
+
+    public function getFreq()
+    {
+
+        return $this->freq;
+    }
+
+
+    public function getFreqAsText()
+    {
+
+        return array_search( $this->freq, self::$frequencies, true );
+    }
+
+
+    // WKST
+
+    public function getInterval()
+    {
+
+        return $this->interval;
+    }
+
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getStartDate()
+    {
+
+        return $this->dtstart;
+    }
+
+
+    public function getUntil()
+    {
+
+        return $this->until;
+    }
+
+
+    public function setByDay( $byDay )
+    {
+
+        if ( ! not_empty( $byDay ) )
+        {
+            $this->byweekday     = null;
+            $this->byweekday_nth = null;
+
+            return $this;
+        }
+        if ( ! is_array( $byDay ) )
+        {
+            $byDay = explode( ',', $byDay );
+        }
+        $new     = [];
+        $new_nth = [];
+        foreach ( $byDay as $value )
+        {
+            $value = strtoupper( trim( $value ) );
+            $valid = preg_match( '/^([+-]?[0-9]+)?([A-Z]{2})$/', $value, $matches );
+            if ( ! $valid
+                || ( not_empty(
+                        $matches[1]
+                    )
+                    && ( $matches[1] == 0 || $matches[1] > 53 || $matches[1] < - 53 ) )
+                || ! array_key_exists( $matches[2], self::$week_days ) )
+            {
+                throw new InvalidArgumentException( 'Invalid BYDAY value: ' . $value );
+            }
+
+            if ( $matches[1] )
+            {
+                $new_nth[] = [
+                    self::$week_days[ $matches[2] ],
+                    (int) $matches[1],
+                ];
+            }
+            else
+            {
+                $new[] = self::$week_days[ $matches[2] ];
+            }
+        }
+        $this->byweekday     = &$new;
+        $this->byweekday_nth = &$new_nth;
+
+        return $this->validate();
+    }
+
+
+    /**
+     * @param $byHour
+     *
+     * @return \RRule\RRule
+     */
+    public function setByHour( $byHour )
+    {
+
+        if ( ! not_empty( $byHour ) )
+        {
+            $this->byhour = null;
+
+            return $this;
+        }
+
+        if ( ! is_array( $byHour ) )
+        {
+            $byHour = explode( ',', $byHour );
+        }
+
+        $new = [];
+        foreach ( $byHour as $value )
+        {
+            if ( filter_var(
+                    $value,
+                    FILTER_VALIDATE_INT,
+                    [
+                        'options' => [
+                            'min_range' => 0,
+                            'max_range' => 23,
+                        ],
+                    ]
+                ) === false )
+            {
+                throw new InvalidArgumentException( 'Invalid BYHOUR value: ' . $value );
+            }
+            $new[] = (int) $value;
+        }
+
+        $this->byhour = &$new;
+        sort( $this->byhour );
+
+        return $this->validate();
+    }
+
+
+    public function setByMinute( $byMinute )
+    {
+
+        if ( ! not_empty( $byMinute ) )
+        {
+            $this->byminute = null;
+
+            return $this;
+        }
+
+        if ( ! is_array( $byMinute ) )
+        {
+            $byMinute = explode( ',', $byMinute );
+        }
+
+        $new = [];
+        foreach ( $byMinute as $value )
+        {
+            if ( filter_var(
+                    $value,
+                    FILTER_VALIDATE_INT,
+                    [
+                        'options' => [
+                            'min_range' => 0,
+                            'max_range' => 59,
+                        ],
+                    ]
+                ) === false )
+            {
+                throw new InvalidArgumentException( 'Invalid BYMINUTE value: ' . $value );
+            }
+            $new[] = (int) $value;
+        }
+        $this->byminute = &$new;
+        sort( $this->byminute );
+
+        return $this->validate();
+    }
+
+
+    /**
+     * The BYMONTH rule part specifies a COMMA-separated list of months
+     * of the year.  Valid values are 1 to 12.
+     *
+     * @param $byMonth
+     *
+     * @return $this|\AcfRRule\RRule
+     */
+    public function setByMonth( $byMonth )
+    {
+
+        if ( ! not_empty( $byMonth ) )
+        {
+            $this->bymonth = null;
+
+            return $this;
+        }
+
+        if ( ! is_array( $byMonth ) )
+        {
+            $byMonth = explode( ',', $byMonth );
+        }
+
+        $new = [];
+        foreach ( $byMonth as $value )
+        {
+            if ( filter_var(
+                    $value,
+                    FILTER_VALIDATE_INT,
+                    [
+                        'options' => [
+                            'min_range' => 1,
+                            'max_range' => 12,
+                        ],
+                    ]
+                ) === false )
+            {
+                throw new InvalidArgumentException( 'Invalid BYMONTH value: ' . $value );
+            }
+            $new[] = (int) $value;
+        }
+        $this->bymonth = &$new;
+
+        return $this;
+    }
+
+
+    /**
+     * The BYMONTHDAY rule part specifies a COMMA-separated list of days
+     * of the month.  Valid values are 1 to 31 or -31 to -1.  For
+     * example, -10 represents the tenth to the last day of the month.
+     * The BYMONTHDAY rule part MUST NOT be specified when the FREQ rule
+     * part is set to WEEKLY.
+     *
+     * @param $byMonthDay string[]|string|null
+     */
+    public function setByMonthDay( $byMonthDay )
+    {
+
+        if ( ! not_empty( $byMonthDay ) )
+        {
+            $this->bymonthday          = null;
+            $this->bymonthday_negative = null;
+
+            return $this;
+        }
+
+        if ( $this->freq === self::WEEKLY )
+        {
+            throw new InvalidArgumentException(
+                'The BYMONTHDAY rule part MUST NOT be specified when the FREQ rule part is set to WEEKLY.'
+            );
+        }
+
+        if ( ! is_array( $byMonthDay ) )
+        {
+            $byMonthDay = explode( ',', $byMonthDay );
+        }
+
+        $new          = [];
+        $new_negative = [];
+        foreach ( $byMonthDay as $value )
+        {
+            if ( ! $value
+                || filter_var(
+                    $value,
+                    FILTER_VALIDATE_INT,
+                    [
+                        'options' => [
+                            'min_range' => - 31,
+                            'max_range' => 31,
+                        ],
+                    ]
+                ) === false )
+            {
+                throw new InvalidArgumentException(
+                    'Invalid BYMONTHDAY value: ' . $value . ' (valid values are 1 to 31 or -31 to -1)'
+                );
+            }
+            $value = (int) $value;
+            if ( $value < 0 )
+            {
+                $new_negative[] = $value;
+            }
+            else
+            {
+                $new[] = $value;
+            }
+        }
+        $this->bymonthday          = &$new;
+        $this->bymonthday_negative = &$new_negative;
+
+        return $this;
+    }
+
+
+    public function setBySecond( $bySecond )
+    {
+
+        if ( ! not_empty( $bySecond ) )
+        {
+            $this->bysecond = null;
+
+            return $this;
+        }
+
+        if ( ! is_array( $bySecond ) )
+        {
+            $bySecond = explode( ',', $bySecond );
+        }
+
+        $new = [];
+        foreach ( $bySecond as $value )
+        {
+            // yes, "60" is a valid value, in (very rare) cases on leap seconds
+            //  December 31, 2005 23:59:60 UTC is a valid date...
+            // so is 2012-06-30T23:59:60UTC
+            if ( filter_var(
+                    $value,
+                    FILTER_VALIDATE_INT,
+                    [
+                        'options' => [
+                            'min_range' => 0,
+                            'max_range' => 60,
+                        ],
+                    ]
+                ) === false )
+            {
+                throw new InvalidArgumentException( 'Invalid BYSECOND value: ' . $value );
+            }
+            $new[] = (int) $value;
+        }
+        $this->bysecond = &$new;
+        sort( $this->bysecond );
+
+        return $this->validate();
+    }
+
+
+    /**
+     * @param $bySetPos int[]|int|string|null Array or comma-separated list of days of year (valid values are 1 to 366
+     *                  or -366 to -1)
+     *
+     * @return \RRule\RRule
+     */
+    public function setBySetPos( $bySetPos )
+    {
+
+        if ( ! not_empty( $bySetPos ) )
+        {
+            $this->bysetpos = null;
+
+            return $this;
+        }
+
+        if ( ! ( not_empty( $this->byweekno ) || not_empty( $this->byyearday )
+            || not_empty( $this->bymonthday )
+            || not_empty( $this->byweekday )
+            || not_empty( $this->byweekday_nth )
+            || not_empty( $this->bymonth )
+            || not_empty( $this->byhour )
+            || not_empty( $this->byminute )
+            || not_empty( $this->bysecond ) ) )
+        {
+            throw new InvalidArgumentException(
+                'The BYSETPOS rule part MUST only be used in conjunction with another BYxxx rule part.'
+            );
+        }
+
+        $new            = $this->parseYearDay( $bySetPos );
+        $this->bysetpos = &$new;
+
+        return $this;
+    }
+
+
+    public function setByWeeNo( $byWeekNo )
+    {
+
+        if ( ! not_empty( $byWeekNo ) )
+        {
+            $this->byweekno = null;
+
+            return $this;
+        }
+
+        if ( $this->freq !== self::YEARLY )
+        {
+            throw new InvalidArgumentException(
+                'The BYWEEKNO rule part MUST NOT be used when the FREQ rule part is set to anything other than YEARLY.'
+            );
+        }
+
+        if ( ! is_array( $byWeekNo ) )
+        {
+            $byWeekNo = explode( ',', $byWeekNo );
+        }
+
+        $new = [];
+        foreach ( $byWeekNo as $value )
+        {
+            if ( ! $value
+                || filter_var(
+                    $value,
+                    FILTER_VALIDATE_INT,
+                    [
+                        'options' => [
+                            'min_range' => - 53,
+                            'max_range' => 53,
+                        ],
+                    ]
+                ) === false )
+            {
+                throw new InvalidArgumentException(
+                    'Invalid BYWEEKNO value: ' . $value . ' (valid values are 1 to 53 or -53 to -1)'
+                );
+            }
+            $new[] = (int) $value;
+        }
+        $this->byweekno = &$new;
+
+        return $this->validate();
+    }
+
+
+    public function setByYearDay( $byYearDay )
+    {
+
+        if ( ! not_empty( $byYearDay ) )
+        {
+            $this->byyearday = null;
+
+            return $this;
+        }
+
+        if ( $this->freq === self::DAILY || $this->freq === self::WEEKLY || $this->freq === self::MONTHLY )
+        {
+            throw new InvalidArgumentException(
+                'The BYYEARDAY rule part MUST NOT be specified when the FREQ rule part is set to DAILY, WEEKLY, or MONTHLY.'
+            );
+        }
+
+        $new             = $this->parseYearDay( $byYearDay );
+        $this->byyearday = &$new;
+
+        return $this->validate();
+    }
+
+
+    public function setCount( $count )
+    {
+
+        if ( not_empty( $count ) )
+        {
+            if ( filter_var( $count, FILTER_VALIDATE_INT, [ 'options' => [ 'min_range' => 1 ] ] ) === false )
+            {
+                throw new InvalidArgumentException( 'COUNT must be a positive integer (> 0)' );
+            }
+            $this->count = (int) $count;
+        }
+
+        return $this->validate();
+    }
+
+
+    public function setFreq( $frequency )
+    {
+
+        if ( is_numeric( $frequency ) && in_array( (int) $frequency, self::$frequencies, true ) )
+        {
+            $this->freq = $frequency;
+        }
+        else
+        { // string
+            $frequency = strtoupper( $frequency );
+            if ( ! array_key_exists( $frequency, self::$frequencies ) )
+            {
+                throw new InvalidArgumentException(
+                    'The FREQ rule part must be one of the following: '
+                    . implode( ', ', array_keys( self::$frequencies ) )
+                );
+            }
+            $this->freq = self::$frequencies[ $frequency ];
+        }
+
+        switch ( $this->freq )
+        {
+        case self::YEARLY:
+            $this->setByDay( null );
+            $this->setByWeeNo( null );
+            break;
+
+        case self::MONTHLY:
+            $this->setByDay( null );
+            break;
+
+        case self::WEEKLY:
+            $this->setByMonthDay( null );
+            break;
+        }
+
+        return $this->validate();
+    }
+
+
+    public function setInterval( $interval )
+    {
+
+        if ( filter_var( $interval, FILTER_VALIDATE_INT, [ 'options' => [ 'min_range' => 1 ] ] ) === false )
+        {
+            throw new InvalidArgumentException(
+                'The INTERVAL rule part must be a positive integer (> 0)'
+            );
+        }
+        $this->interval = (int) $interval;
+
+        return $this;
+    }
+
+
+    public function setStart( $dtstart )
+    {
+
+        if ( not_empty( $dtstart ) )
+        {
+            try
+            {
+                $this->dtstart = self::parseDate( $dtstart );
+            }
+            catch ( Exception $e )
+            {
+                throw new InvalidArgumentException(
+                    'Failed to parse DTSTART ; it must be a valid date, timestamp or \DateTime object'
+                );
+            }
+        }
+        else
+        {
+            $this->dtstart = new DateTime(); // for PHP 7.1+ this contains microseconds which causes many problems
+            if ( version_compare( PHP_VERSION, '7.1.0' ) >= 0 )
+            {
+                // remove microseconds
+                $this->dtstart->setTime(
+                    $this->dtstart->format( 'H' ),
+                    $this->dtstart->format( 'i' ),
+                    $this->dtstart->format( 's' ),
+                    0
+                );
+            }
+        }
+
+        return $this;
+    }
+
+
+    public function setUntil( $until )
+    {
+
+        if ( not_empty( $until ) )
+        {
+            try
+            {
+                $this->until = self::parseDate( $until );
+            }
+            catch ( Exception $e )
+            {
+                throw new InvalidArgumentException(
+                    'Failed to parse UNTIL ; it must be a valid date, timestamp or \DateTime object'
+                );
+            }
+        }
+
+        return $this->validate();
+    }
+
+
+    public function setWkst( $wkst )
+    {
+
+        if ( ! not_empty( $wkst ) )
+        {
+            $this->wkst = null;
+
+            return $this;
+        }
+
+        $wkst = strtoupper( $wkst );
+        if ( ! array_key_exists( $wkst, self::$week_days ) )
+        {
+            throw new InvalidArgumentException(
+                'The WKST rule part must be one of the following: '
+                . implode( ', ', array_keys( self::$week_days ) )
+            );
+        }
+        $this->wkst = self::$week_days[ $wkst ];
+
+        return $this;
+    }
+
+
+    /**
+     * @param $byYearDay
+     *
+     * @return array
+     */
+    public function &parseYearDay( $byYearDay )
+    {
+
+        if ( ! is_array( $byYearDay ) )
+        {
+            $byYearDay = explode( ',', $byYearDay );
+        }
+
+        $new = [];
+        foreach ( $byYearDay as $value )
+        {
+            if ( ! $value
+                || filter_var(
+                    $value,
+                    FILTER_VALIDATE_INT,
+                    [
+                        'options' => [
+                            'min_range' => - 366,
+                            'max_range' => 366,
+                        ],
+                    ]
+                ) === false )
+            {
+                throw new InvalidArgumentException(
+                    'Invalid BYSETPOS value: ' . $value . ' (valid values are 1 to 366 or -366 to -1)'
+                );
+            }
+
+            $new[] = (int) $value;
+        }
+
+        return $new;
+    }
+
+
+    public function validate()
+    {
+
+        if ( $this->until && $this->count )
+        {
+            throw new InvalidArgumentException( 'The UNTIL or COUNT rule parts MUST NOT occur in the same rule' );
+        }
+
+        if ( ! empty( $this->byweekday_nth ) )
+        {
+            if ( ! ( $this->freq === self::MONTHLY || $this->freq === self::YEARLY ) )
+            {
+                throw new InvalidArgumentException(
+                    'The BYDAY rule part MUST NOT be specified with a numeric value when the FREQ rule part is not set to MONTHLY or YEARLY.'
+                );
+            }
+            if ( $this->freq === self::YEARLY && not_empty( $this->byweekno ) )
+            {
+                throw new InvalidArgumentException(
+                    'The BYDAY rule part MUST NOT be specified with a numeric value with the FREQ rule part set to YEARLY when the BYWEEKNO rule part is specified.'
+                );
+            }
+        }
+
+        if ( $this->freq < self::HOURLY )
+        {
+            // for frequencies DAILY, WEEKLY, MONTHLY AND YEARLY, we can build
+            // an array of every time of the day at which there should be an
+            // occurrence - default, if no BYHOUR/BYMINUTE/BYSECOND are provided
+            // is only one time, and it's the DTSTART time. This is a cached version
+            // if you will, since it'll never change at these frequencies
+            $this->timeset = [];
+            foreach ( $this->getByHour() as $hour )
+            {
+                foreach ( $this->getByMinute() as $minute )
+                {
+                    foreach ( $this->getBySecond() as $second )
+                    {
+                        $this->timeset[] = [
+                            $hour,
+                            $minute,
+                            $second,
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $this;
+    }
+
+}


### PR DESCRIPTION
As discussed in https://github.com/marcbelletre/acf-rrule/issues/7, there is a point in switching the library for doing the parsing and date calculations. The PR implements that change.

Happy to update the PR to match code style or other requirements/suggestions.